### PR TITLE
mediaControls: don't filter updates on elapsed

### DIFF
--- a/src/mediaControls/manifest.json
+++ b/src/mediaControls/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
   "id": "mediaControls",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "apiLevel": 2,
   "meta": {
     "name": "Media Controls",
@@ -9,7 +9,8 @@
     "description": "**Configuration required!**\nFor this extension to work, you must enable which media sources to use.\n- To use Spotify, your Spotify account must be linked to your Discord account.\n- To use the system media player, you must [build the media fetcher from source](https://github.com/NotNite/my-moonlight-extensions/tree/main/src/mediaControls/media-fetcher) and set the path to the executable.",
     "authors": ["NotNite", "Cynosphere"],
     "source": "https://github.com/NotNite/my-moonlight-extensions",
-    "donate": "https://notnite.com/givememoney"
+    "donate": "https://notnite.com/givememoney",
+    "changelog": "Fix broken seekbar when using spotify"
   },
   "dependencies": ["spacepack", "appPanels", "common"],
   "settings": {

--- a/src/mediaControls/webpackModules/ui.tsx
+++ b/src/mediaControls/webpackModules/ui.tsx
@@ -99,11 +99,8 @@ function MediaControlsUI() {
 
   // Basic elapsed time calculation
   React.useEffect(() => {
-    const variance = 0.1;
     const nowElapsed = state?.elapsed ?? 0;
-    if (Math.abs(nowElapsed - realElapsed) > variance) {
-      setRealElapsed(nowElapsed);
-    }
+    setRealElapsed(nowElapsed);
   }, [state]);
 
   React.useEffect(() => {


### PR DESCRIPTION
spotify doesn't send track elapsed updates routinely so filtering updates makes the seekbar go over 100%

the component was getting a bunch of rerenders nonetheless so filtering didn't do much