### PR TITLE
mediaControls: add richPresencePlayerRegex setting

### DIFF
--- a/src/mediaControls/manifest.json
+++ b/src/mediaControls/manifest.json
@@ -47,6 +47,13 @@
       "default": "music",
       "advice": "none"
     },
+    "richPresencePlayerRegex": {
+      "displayName": "Rich Presence -> Player Allow Filter Regex",
+      "description": "(Optional) Regex to match player names that should be allowed to display a presence",
+      "type": "string",
+      "default": "",
+      "advice": "reload"
+    },
     "richPresenceProvidedTitle": {
       "displayName": "Rich Presence -> Use Provided Title",
       "description": "Will use title string if none is provided by the player",

--- a/src/mediaControls/webpackModules/richPresence.ts
+++ b/src/mediaControls/webpackModules/richPresence.ts
@@ -404,6 +404,9 @@ let running = false;
 let lastState: MediaState | undefined;
 async function onChange() {
   const enabled = moonlight.getConfigOption<boolean>("mediaControls", "richPresence") ?? false;
+
+  const playerReStr = moonlight.getConfigOption<string>("mediaControls", "richPresencePlayerRegex");
+  const playerRe = playerReStr ? new RegExp(playerReStr, "g") : null;
   const state = MediaControlsStore.getState();
 
   if ((!state || !enabled) && running) {
@@ -412,7 +415,10 @@ async function onChange() {
     lastState = undefined;
   } else if (state && enabled) {
     running = true;
-    if (SPOTIFY_PLAYER_NAMES.includes(state.player_name ?? "")) {
+    if (
+      SPOTIFY_PLAYER_NAMES.includes(state.player_name ?? "") ||
+      (playerRe !== null && !playerRe.test(state.player_name ?? ""))
+    ) {
       sendActivity();
     } else if (
       !lastState ||


### PR DESCRIPTION
Adds optional setting `Rich Presence -> Player Allow Filter Regex`, with default value `""` which allows all player names

<img width="635" alt="image" src="https://github.com/user-attachments/assets/69e22f65-7cdf-4002-bcba-e1eb89973666" />
