### PR TITLE
media-fetcher: upgrade media-remote to 0.1.2

### DIFF
--- a/src/mediaControls/media-fetcher/Cargo.lock
+++ b/src/mediaControls/media-fetcher/Cargo.lock
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "media-remote"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27bcdaf6e66a28a0030b93aec2cb7486783afc4cd4e13698d6b9c151a3fd680"
+checksum = "806fc09409239ea17473901f7998134f5a9d807e1f47cbb2ac2101dfede8a685"
 dependencies = [
  "block2",
  "dispatch2",

--- a/src/mediaControls/media-fetcher/Cargo.toml
+++ b/src/mediaControls/media-fetcher/Cargo.toml
@@ -24,4 +24,4 @@ windows = { version = "0.57.0", features = [
 mpris = "2.0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-media-remote = "0.1.1"
+media-remote = "0.1.2"


### PR DESCRIPTION
Fixes album art not being loadable for some apps that provided the image data in a different obj-c class than expected (`_NSInlineData` vs `NSSubrangeData`). 
[the commit in media-remote](https://github.com/nohackjustnoobb/media-remote/commit/58d0ba563122295f47c771f6933474f408da1355)