### PR TITLE
imageViewer: Use CSS properties

### DIFF
--- a/src/imageViewer/style.css
+++ b/src/imageViewer/style.css
@@ -26,6 +26,16 @@
   pointer-events: none;
 }
 
+.imageViewer-container {
+  --image-viewer-scale: 100%;
+  --image-viewer-x: 0px;
+  --image-viewer-y: 0px;
+  --image-viewer-rotate: 0deg;
+
+  transform: scale(var(--image-viewer-scale)) translate(var(--image-viewer-x), var(--image-viewer-y))
+    rotate(var(--image-viewer-rotate));
+}
+
 .imageViewer-container,
 .imageViewer-toolbar {
   pointer-events: auto;


### PR DESCRIPTION
Got bored and irrationally upset at the amount of reran hooks in imageViewer. It doesn't actually improve performance that much ime (lol) but it should feel better in some cases. The component still redraws a lot but most of the callbacks/event listeners don't get spammed anymore. Tested on my laptop with 200% DPI scaling, so that should still work fine (our calculations don't even seem to be needed anymore???).