### PR TITLE
css: add option to forcibly enable the custom-theme-background class

### DIFF
--- a/src/moonlight-css/index.ts
+++ b/src/moonlight-css/index.ts
@@ -1,6 +1,8 @@
 import { ExtensionWebExports } from "@moonlight-mod/types";
 
 const themeAttributes = () => moonlight.getConfigOption<boolean>("moonlight-css", "themeAttributes") ?? false;
+const customThemeBackground = () =>
+  moonlight.getConfigOption<boolean>("moonlight-css", "customThemeBackground") ?? false;
 
 export const patches: ExtensionWebExports["patches"] = [
   //#region Theme Attributes Patches
@@ -45,9 +47,19 @@ export const patches: ExtensionWebExports["patches"] = [
         `"img",{style:require("moonlight-css_themeAttributes").avatarUrls(${avatar}),src:null!=${avatar}?`
     },
     prerequisite: themeAttributes
-  }
+  },
 
   //#endregion
+
+  // force custom-theme-background class
+  {
+    find: "RootElementContextProvider",
+    replace: {
+      match: /"keyboard-mode":(\i),/,
+      replacement: '$&"custom-theme-background":!0,'
+    },
+    prerequisite: customThemeBackground
+  }
 ];
 
 export const webpackModules: ExtensionWebExports["webpackModules"] = {

--- a/src/moonlight-css/manifest.json
+++ b/src/moonlight-css/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
   "id": "moonlight-css",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "apiLevel": 2,
   "meta": {
     "name": "CSS",
@@ -10,7 +10,7 @@
     "authors": ["NotNite", "husky"],
     "source": "https://github.com/NotNite/my-moonlight-extensions",
     "tags": ["appearance"],
-    "changelog": "Fix Sass files not reloading"
+    "changelog": "Add option to forcibly enable the custom-theme-background class"
   },
   "settings": {
     "paths": {
@@ -29,6 +29,13 @@
     "themeAttributes": {
       "displayName": "Theme Attributes",
       "description": "Adds data attributes and CSS variables to some elements. Some themes have extra functionality with this enabled.",
+      "type": "boolean",
+      "default": false,
+      "advice": "reload"
+    },
+    "customThemeBackground": {
+      "displayName": "Enable custom theme background colors",
+      "description": "Forcibly enables the `custom-theme-background` class on the root element, which may be required for some themes but may break others.",
       "type": "boolean",
       "default": false,
       "advice": "reload"


### PR DESCRIPTION
meow